### PR TITLE
Add golang 1.4.2

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -91,7 +91,13 @@ dependencies:
     cf_stacks:
       - lucid64
       - cflinuxfs2
-
+  - name: go
+    version: 1.4.2
+    uri: https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz
+    md5: cdc1ff96c6c99b918402693a5cf0e1f3 
+    cf_stacks:
+      - lucid64
+      - cflinuxfs2
 exclude_files:
   - .git/
   - .gitignore


### PR DESCRIPTION
This helps with golang version with 1.4.2, when Godeps/Godeps.json has 

"GoVersion": "go1.4.2"