### PR TITLE
Fail compile stage if builds fail

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -216,6 +216,10 @@ else
     go get "${FLAGS[@]}" ./...
 fi
 
+if [ $? -ne 0 ] ; then 
+	exit 1
+fi
+
 rm -rf $build/.heroku
 
 mkdir -p $build/.profile.d


### PR DESCRIPTION
We had a difficult time troubleshooting today where builds failed but the compile stage did not. This changes causes a more explicit error. 