### PR TITLE
Fixed linker for all versions >= 1.5

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -240,14 +240,11 @@ export GOROOT="${cache}/${ver}/go"
 FLAGS=(-tags cloudfoundry)
 if [ -n "${GO_LINKER_SYMBOL}" -a -n "${GO_LINKER_VALUE}" ]
 then
-    case $ver in
-    go1.5*|go1.6*)
-        xval="${GO_LINKER_SYMBOL}=${GO_LINKER_VALUE}"
-        ;;
-    *)
+    if [[ "$ver" < "go1.5" ]]; then
         xval="${GO_LINKER_SYMBOL} ${GO_LINKER_VALUE}"
-        ;;
-    esac
+    else
+        xval="${GO_LINKER_SYMBOL}=${GO_LINKER_VALUE}"
+    fi
     FLAGS+=(-ldflags "-X ${xval}")
 fi
 


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:
- A short explanation of the proposed change:

When specifying go1.7 or better, the linker would break because the test only checked for go1.5\* and go1.6*.  This fixes that problem by testing instead for <go1.5, which works in bash.
- An explanation of the use cases your change solves
- [x] I have viewed signed and have submitted the Contributor License Agreement
- [x] I have made this pull request to the `develop` branch
