### PR TITLE
Add deprecation warning to appdynamics agent integration

### DIFF
--- a/src/go/hooks/appdynamics.go
+++ b/src/go/hooks/appdynamics.go
@@ -58,7 +58,6 @@ func (h AppdynamicsHook) GenerateAppdynamicsScript(envVars map[string]string) st
 	return scriptContents
 }
 
-
 func (h AppdynamicsHook) CreateAppDynamicsEnv(stager *libbuildpack.Stager, environmentVars map[string]string) error {
 	scriptContents := h.GenerateAppdynamicsScript(environmentVars)
 	h.Log.BeginStep("Writing Appdynamics Environment")
@@ -67,6 +66,15 @@ func (h AppdynamicsHook) CreateAppDynamicsEnv(stager *libbuildpack.Stager, envir
 }
 
 func (h AppdynamicsHook) BeforeCompile(stager *libbuildpack.Stager) error {
+	if os.Getenv("APPD_AGENT") != "" {
+		// APPD_AGENT is set => multibuildpack is used to configure appdynamics agent. Do nothing.
+		return nil
+	}
+
+	h.Log.Warning("[DEPRECATION WARNING]:")
+	h.Log.Warning("Please use AppDynamics extension buildpack for Golang Application instrumentation")
+	h.Log.Warning("for more details: https://docs.pivotal.io/partners/appdynamics/multibuildpack.html")
+
 	vcapServices := os.Getenv("VCAP_SERVICES")
 	services := make(map[string][]Plan)
 


### PR DESCRIPTION
So far, appdynamics agent configuration has been carried out via hooks mechanism present in the builldpack. Moving forward, we would like to do so using multi buildpack approach. We have already move configuration logic to our supply buildpack (appdbuildpack) which is released as a part of our Service Broker Tile.

But for some time we would like to issue a deprecation warning till all our users move to using multi buildpack approach.

During this time users can still use cloudfoundry buildpacks to configure appdynamics agents and instrument applications.

Users who would like to move multi buildpack approach can set APPD_AGENT env variable which will route the configuration logic supply buildpack and omits standard buildpack.

[x ] I have viewed signed and have submitted the Contributor License Agreement

[ x] I have made this pull request to the develop branch

[ ] I have added an integration test