### PR TITLE
Allowed for multiple ldflags to be specified

### DIFF
--- a/fixtures/go_ldflags_multiple/src/go_app/Godeps/Godeps.json
+++ b/fixtures/go_ldflags_multiple/src/go_app/Godeps/Godeps.json
@@ -1,0 +1,5 @@
+{
+	"ImportPath": "go-online",
+	"GoVersion": "go1.X",
+	"Deps": []
+}

--- a/fixtures/go_ldflags_multiple/src/go_app/Godeps/Readme
+++ b/fixtures/go_ldflags_multiple/src/go_app/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/fixtures/go_ldflags_multiple/src/go_app/Procfile
+++ b/fixtures/go_ldflags_multiple/src/go_app/Procfile
@@ -1,0 +1,1 @@
+web: go-online

--- a/fixtures/go_ldflags_multiple/src/go_app/README.md
+++ b/fixtures/go_ldflags_multiple/src/go_app/README.md
@@ -1,0 +1,12 @@
+go-online
+=========
+
+Sample go web app using the GoLang example: http://golang.org/doc/articles/wiki/final.go
+
+to run
+======
+
+```
+$ go build site.go
+$ PORT=3000 ./site
+```

--- a/fixtures/go_ldflags_multiple/src/go_app/manifest.yml
+++ b/fixtures/go_ldflags_multiple/src/go_app/manifest.yml
@@ -1,0 +1,4 @@
+---
+  env:
+    GO_LINKER_SYMBOL: main.linker_flag,main.the_other_flag
+    GO_LINKER_VALUE: flag_linked,the_other_value

--- a/fixtures/go_ldflags_multiple/src/go_app/site.go
+++ b/fixtures/go_ldflags_multiple/src/go_app/site.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+var linker_flag string
+var the_other_flag string
+
+func main() {
+	http.HandleFunc("/", hello)
+	fmt.Println("listening...")
+	err := http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func hello(res http.ResponseWriter, req *http.Request) {
+	fmt.Fprintln(res, linker_flag)
+	fmt.Fprintln(res, the_other_flag)
+	fmt.Fprintln(res, "done")
+}

--- a/src/go/integration/deploy_a_go_app_test.go
+++ b/src/go/integration/deploy_a_go_app_test.go
@@ -445,6 +445,23 @@ var _ = Describe("CF Go Buildpack", func() {
 			AssertNoInternetTraffic("go_ldflags/src/go_app")
 		})
 
+		Context("a go app using multiple ldflags", func() {
+			BeforeEach(func() {
+				app = cutlass.New(filepath.Join(bpDir, "fixtures", "go_ldflags_multiple", "src", "go_app"))
+			})
+
+			It("links correctly", func() {
+				PushAppAndConfirm(app)
+
+				Expect(app.GetBody("/")).To(ContainSubstring("flag_linked"))
+				Expect(app.GetBody("/")).To(ContainSubstring("the_other_value"))
+				Expect(app.Stdout.String()).To(ContainSubstring("main.linker_flag=flag_linked"))
+				Expect(app.Stdout.String()).To(ContainSubstring("main.the_other_flag=the_other_value"))
+			})
+
+			AssertNoInternetTraffic("go_ldflags_multiple/src/go_app")
+		})
+
 		Context("app uses glide and has vendored dependencies", func() {
 			BeforeEach(func() {
 				app = cutlass.New(filepath.Join(bpDir, "fixtures", "glide_and_vendoring", "src", "glide_and_vendoring"))


### PR DESCRIPTION
* A short explanation of the proposed change:

Allowed multiple ldflags to be specified to the linker. I ensured that they are comma separated and enabled an escape mechanism so you can also do that. I'm unaware of where a good place to document this is but will as needed.

* An explanation of the use cases your change solves

When you want to include more than just a single value or want to avoid providing a serialized JSON string to deserialize into the struct will applicable information.

In my scenario, we provide a buildDate, commitDate, versionString, etc when building binaries to enhance our ability to audit & track binaries. Being able to specify multiple ldflags greatly simplifies this step so that I can continue using the go-buildpack instead of the binary one.

* [X] I have viewed signed and have submitted the Contributor License Agreement - *Should be covered under corporate agreements (Dell EMC employee)*

* [X] I have made this pull request to the `develop` branch

* [X] I have added an integration test
