### PR TITLE
Updating version for go for 1.13.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -30,14 +30,6 @@ dependencies:
   source: https://github.com/Masterminds/glide/archive/v0.13.3.tar.gz
   source_sha256: 817dad2f25303d835789c889bf2fac5e141ad2442b9f75da7b164650f0de3fee
 - name: go
-  version: 1.13.9
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go1.13.9.linux-amd64-cflinuxfs3-42e2eee8.tgz
-  sha256: 42e2eee8543a98b2cf57035aade9b53f20cd7214861bb8ddf50953b097f8bfc6
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.13.9.src.tar.gz
-  source_sha256: 34bb19d806e0bc4ad8f508ae24bade5e9fedfa53d09be63b488a9314d2d4f31d
-- name: go
   version: 1.13.10
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.13.10_linux_x64_cflinuxfs3_676f441b.tgz
   sha256: 676f441b1f043f7ccb875906bd5869d630af3ff0db36c805677e8aa60e67c86a
@@ -45,6 +37,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.13.10.src.tar.gz
   source_sha256: eb9ccc8bf59ed068e7eff73e154e4f5ee7eec0a47a610fb864e3332a2fdc8b8c
+- name: go
+  version: 1.13.11
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.13.11_linux_x64_cflinuxfs3_2121cff4.tgz
+  sha256: 2121cff4d44a95cd1069bb287f4790471e85ddcbc9055cb1cc768a326bc006f6
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.13.11.src.tar.gz
+  source_sha256: 89ed1abce25ad003521c125d6583c93c1280de200ad221f961085200a6c00679
 - name: go
   version: 1.14.1
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go1.14.1.linux-amd64-cflinuxfs3-769c2113.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.