### PR TITLE
Updating version for go for 1.14.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -46,14 +46,6 @@ dependencies:
   source: https://dl.google.com/go/go1.13.12.src.tar.gz
   source_sha256: 17ba2c4de4d78793a21cc659d9907f4356cd9c8de8b7d0899cdedcef712eba34
 - name: go
-  version: 1.14.2
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.14.2_linux_x64_cflinuxfs3_11e7a451.tgz
-  sha256: 11e7a4512af39fabddb558f88a7162a530e3136b1204f293d164b5d9ecc59ad0
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.14.2.src.tar.gz
-  source_sha256: 98de84e69726a66da7b4e58eac41b99cbe274d7e8906eeb8a5b7eb0aadee7f7c
-- name: go
   version: 1.14.4
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.14.4_linux_x64_cflinuxfs3_73fa2a10.tgz
   sha256: 73fa2a105323f57e3d13fe710d856e1438861aff561f5270d8d442ab004be857
@@ -61,6 +53,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.14.4.src.tar.gz
   source_sha256: 7011af3bbc2ac108d1b82ea8abb87b2e63f78844f0259be20cde4d42c5c40584
+- name: go
+  version: 1.14.5
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.14.5_linux_x64_cflinuxfs3_3f7111b6.tgz
+  sha256: 3f7111b6fa76d86421563a1cf768a90e1c8d3d5986926a72601d7e7e81884889
+  cf_stacks:
+  - cflinuxfs3
+  source: "/dl/go1.14.5.src.tar.gz"
+  source_sha256: ca4c080c90735e56152ac52cd77ae57fe573d1debb1a58e03da9cc362440315c
 - name: godep
   version: '80'
   uri: https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v80-linux-x64-cflinuxfs3-b60ac947.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.