### PR TITLE
Updating version for go for 1.13.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -43,7 +43,7 @@ dependencies:
   sha256: 3f0cac97dd2bb415a094b6ba59c1f528f3f8ac080094b544050ece6d2cfd35b0
   cf_stacks:
   - cflinuxfs3
-  source: "/dl/go1.13.14.src.tar.gz"
+  source: https://dl.google.com/go/go1.13.14.src.tar.gz
   source_sha256: 197333e97290e9ea8796f738d61019dcba1c377c2f3961fd6a114918ecc7ab06
 - name: go
   version: 1.14.4
@@ -59,7 +59,7 @@ dependencies:
   sha256: 3f7111b6fa76d86421563a1cf768a90e1c8d3d5986926a72601d7e7e81884889
   cf_stacks:
   - cflinuxfs3
-  source: "/dl/go1.14.5.src.tar.gz"
+  source: https://dl.google.com/go/go1.14.5.src.tar.gz
   source_sha256: ca4c080c90735e56152ac52cd77ae57fe573d1debb1a58e03da9cc362440315c
 - name: godep
   version: '80'

--- a/manifest.yml
+++ b/manifest.yml
@@ -30,14 +30,6 @@ dependencies:
   source: https://github.com/Masterminds/glide/archive/v0.13.3.tar.gz
   source_sha256: 817dad2f25303d835789c889bf2fac5e141ad2442b9f75da7b164650f0de3fee
 - name: go
-  version: 1.13.11
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.13.11_linux_x64_cflinuxfs3_2121cff4.tgz
-  sha256: 2121cff4d44a95cd1069bb287f4790471e85ddcbc9055cb1cc768a326bc006f6
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.13.11.src.tar.gz
-  source_sha256: 89ed1abce25ad003521c125d6583c93c1280de200ad221f961085200a6c00679
-- name: go
   version: 1.13.12
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.13.12_linux_x64_cflinuxfs3_171f8b81.tgz
   sha256: 171f8b81bc50c4efc1ecd618ad418edd4843556e65f2850167bb40ba57c81b48
@@ -45,6 +37,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.13.12.src.tar.gz
   source_sha256: 17ba2c4de4d78793a21cc659d9907f4356cd9c8de8b7d0899cdedcef712eba34
+- name: go
+  version: 1.13.14
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.13.14_linux_x64_cflinuxfs3_3f0cac97.tgz
+  sha256: 3f0cac97dd2bb415a094b6ba59c1f528f3f8ac080094b544050ece6d2cfd35b0
+  cf_stacks:
+  - cflinuxfs3
+  source: "/dl/go1.13.14.src.tar.gz"
+  source_sha256: 197333e97290e9ea8796f738d61019dcba1c377c2f3961fd6a114918ecc7ab06
 - name: go
   version: 1.14.4
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.14.4_linux_x64_cflinuxfs3_73fa2a10.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.