### PR TITLE
Updating version for go for 1.13.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -39,11 +39,11 @@ dependencies:
   source_sha256: ab7e44461e734ce1fd5f4f82c74c6d236e947194d868514d48a2b1ea73d25137
 - name: go
   version: 1.13.14
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.13.14_linux_x64_cflinuxfs3_3f0cac97.tgz
-  sha256: 3f0cac97dd2bb415a094b6ba59c1f528f3f8ac080094b544050ece6d2cfd35b0
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.13.14_linux_x64_cflinuxfs3_d07cf895.tgz
+  sha256: d07cf8956dc1fddd1654ce40e3dcbae25cca20ae05f2f8c16668daf1c0958789
   cf_stacks:
   - cflinuxfs3
-  source: "/dl/go1.13.14.src.tar.gz"
+  source: https://dl.google.com/go/go1.13.14.src.tar.gz
   source_sha256: 197333e97290e9ea8796f738d61019dcba1c377c2f3961fd6a114918ecc7ab06
 - name: go
   version: 1.14.5


### PR DESCRIPTION
This PR is made automatically by release engineering bot.