### PR TITLE
Updating version for go for 1.14.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -50,14 +50,6 @@ dependencies:
   source: https://dl.google.com/go/go1.13.15.src.tar.gz
   source_sha256: 5fb43171046cf8784325e67913d55f88a683435071eef8e9da1aa8a1588fcf5d
 - name: go
-  version: 1.14.6
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.14.6_linux_x64_cflinuxfs3_dae88e80.tgz
-  sha256: dae88e8007806194ad81aec74cc7f068c2ccc32615adea0ea7c88b593ee080ed
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.14.6.src.tar.gz
-  source_sha256: 73fc9d781815d411928eccb92bf20d5b4264797be69410eac854babe44c94c09
-- name: go
   version: 1.14.7
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.14.7_linux_x64_cflinuxfs3_edc2c096.tgz
   sha256: edc2c096989a90d57cd023785a686f0b9bfe945bb8b22f2a92cd51fda25cadd9
@@ -65,6 +57,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.14.7.src.tar.gz
   source_sha256: '064392433563660c73186991c0a315787688e7c38a561e26647686f89b6c30e3'
+- name: go
+  version: 1.14.8
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.14.8_linux_x64_cflinuxfs3_6c94e519.tgz
+  sha256: 6c94e519ac658acf9cc1b2d1482759320320cddee1837618397228bab7bca7ef
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.14.8.src.tar.gz
+  source_sha256: d9a613fb55f508cf84e753456a7c6a113c8265839d5b7fe060da335c93d6e36a
 - name: go
   version: '1.15'
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.15_linux_x64_cflinuxfs3_4e73b8b4.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.