### PR TITLE
Updating version for go for 1.16.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -61,6 +61,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.15.8.src.tar.gz
   source_sha256: 540c0ab7781084d124991321ed1458e479982de94454a98afab6acadf38497c2
+- name: go
+  version: '1.16'
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16_linux_x64_cflinuxfs3_4ebb61dc.tgz
+  sha256: 4ebb61dcdcc0e20a97947264b2a58168645d8440c0f6c2040bab746589976454
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.16.src.tar.gz
+  source_sha256: 7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a
 - name: godep
   version: '80'
   uri: https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v80-linux-x64-cflinuxfs3-b60ac947.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.