### PR TITLE
Updating version for go for 1.15.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -46,14 +46,6 @@ dependencies:
   source: https://dl.google.com/go/go1.14.15.src.tar.gz
   source_sha256: 7ed13b2209e54a451835997f78035530b331c5b6943cdcd68a3d815fdc009149
 - name: go
-  version: 1.15.7
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.15.7_linux_x64_cflinuxfs3_fa481c84.tgz
-  sha256: fa481c843585d4618a561109dd772857b73bca0fb2439f5e4bda1488c40ab77c
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.15.7.src.tar.gz
-  source_sha256: 8631b3aafd8ecb9244ec2ffb8a2a8b4983cf4ad15572b9801f7c5b167c1a2abc
-- name: go
   version: 1.15.8
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.15.8_linux_x64_cflinuxfs3_cd5a88c6.tgz
   sha256: cd5a88c603caa848f47424bf2401ab7d256d181b2f1e77a79bf6d7dab69b7782
@@ -61,6 +53,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.15.8.src.tar.gz
   source_sha256: 540c0ab7781084d124991321ed1458e479982de94454a98afab6acadf38497c2
+- name: go
+  version: 1.15.9
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.15.9_linux_x64_cflinuxfs3_7fef8ba6.tgz
+  sha256: 7fef8ba6a0786143efcce66b0bbfbfbab02afeef522b4e09833c5b550d7741ad
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.15.9.src.tar.gz
+  source_sha256: 90983b9c84a92417337dc1942ff066fc8b3a69733b8b5493fd0b9b9db1ead60f
 - name: go
   version: '1.16'
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16_linux_x64_cflinuxfs3_4ebb61dc.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.