### PR TITLE
Updating version for go for 1.16.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -69,6 +69,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.16.src.tar.gz
   source_sha256: 7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a
+- name: go
+  version: 1.16.1
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.1_linux_x64_cflinuxfs3_c5f8cca1.tgz
+  sha256: c5f8cca1958fc434ce8312cf89514d7ec101b8360c9c8d5c5b70b6b27840d2a7
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.16.1.src.tar.gz
+  source_sha256: 680a500cd8048750121677dd4dc055fdfd680ae83edc7ed60a4b927e466228eb
 - name: godep
   version: '80'
   uri: https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v80-linux-x64-cflinuxfs3-b60ac947.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.