### PR TITLE
Bumped  libbuildpack-dynatrace to 1.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cloudfoundry/go-buildpack
 
 require (
-	github.com/Dynatrace/libbuildpack-dynatrace v1.3.0
+	github.com/Dynatrace/libbuildpack-dynatrace v1.4.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/ZiCog/shiny-thing v0.0.0-20121130081921-e9e19444ccf5
 	github.com/cloudfoundry/libbuildpack v0.0.0-20210608233952-b5d1ff03c407

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cloudfoundry/go-buildpack
 
 require (
-	github.com/Dynatrace/libbuildpack-dynatrace v1.4.0
+	github.com/Dynatrace/libbuildpack-dynatrace v1.4.1
 	github.com/Masterminds/semver v1.5.0
 	github.com/ZiCog/shiny-thing v0.0.0-20121130081921-e9e19444ccf5
 	github.com/cloudfoundry/libbuildpack v0.0.0-20210608233952-b5d1ff03c407

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Dynatrace/libbuildpack-dynatrace v1.3.0 h1:Gr3npoRtYUe4U+4V2vwAW1TiEcFckMHeYlkguVSnnCU=
 github.com/Dynatrace/libbuildpack-dynatrace v1.3.0/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
+github.com/Dynatrace/libbuildpack-dynatrace v1.4.0 h1:4zvEFkyR8rlH+UbH1WQpo74cTFT3DpPsklJiQdGmpNU=
+github.com/Dynatrace/libbuildpack-dynatrace v1.4.0/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/Dynatrace/libbuildpack-dynatrace v1.3.0 h1:Gr3npoRtYUe4U+4V2vwAW1TiEc
 github.com/Dynatrace/libbuildpack-dynatrace v1.3.0/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
 github.com/Dynatrace/libbuildpack-dynatrace v1.4.0 h1:4zvEFkyR8rlH+UbH1WQpo74cTFT3DpPsklJiQdGmpNU=
 github.com/Dynatrace/libbuildpack-dynatrace v1.4.0/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
+github.com/Dynatrace/libbuildpack-dynatrace v1.4.1 h1:1IMG4xR/UgfcLxzCA/kRfZ05Tbx4MsHt1MDdkTEk/Ks=
+github.com/Dynatrace/libbuildpack-dynatrace v1.4.1/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/src/go/integration/go_app_with_dynatrace_test.go
+++ b/src/go/integration/go_app_with_dynatrace_test.go
@@ -78,6 +78,31 @@ var _ = Describe("CF Go Buildpack", func() {
 			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace OneAgent injection is set up."))
 		})
 	})
+	
+	Context("deploying a Go app with Dynatrace agent with configured network zone", func() {
+		It("checks if networkzone setting was successful", func() {
+			serviceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
+			command := exec.Command("cf", "cups", serviceName, "-p", fmt.Sprintf("'{\"apitoken\":\"secretpaastoken\",\"apiurl\":\"%s\",\"environmentid\":\"envid\", \"networkzone\":\"testzone\"}'", dynatraceAPIURI))
+			_, err := command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, serviceName)
+
+			command = exec.Command("cf", "bind-service", app.Name, serviceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+			command = exec.Command("cf", "restage", app.Name)
+			_, err = command.Output()
+			Expect(err).To(BeNil())
+
+			Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace service credentials found. Setting up Dynatrace OneAgent."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Starting Dynatrace OneAgent installer"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Copy dynatrace-env.sh"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Setting DT_NETWORK_ZONE..."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace OneAgent installed."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace OneAgent injection is set up."))
+		})
+	})
 
 	Context("deploying a Go app with Dynatrace agent with two credentials services", func() {
 		It("checks if detection of second service with credentials works", func() {


### PR DESCRIPTION
* A short explanation of the proposed change:
Bumped  libbuildpack-dynatrace to 1.4.1 to include the networkzone parameter when downloading the OneAgent from the API
* An explanation of the use cases your change solves
This includes the networkzone parameter when downloading the OneAgent from the API
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
