### PR TITLE
Updating version for go for 1.16.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -42,14 +42,6 @@ dependencies:
   source: https://dl.google.com/go/go1.15.14.src.tar.gz
   source_sha256: 60a4a5c48d63d0a13eca8849009b624629ff429c8bc5d1a6a8c3c4da9f34e70a
 - name: go
-  version: 1.16.5
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.5_linux_x64_cflinuxfs3_89520cb9.tgz
-  sha256: 89520cb99f93060a3cf2598456c676d24377edbf9d3af524b939f6bf0ce6b6b9
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.16.5.src.tar.gz
-  source_sha256: 7bfa7e5908c7cc9e75da5ddf3066d7cbcf3fd9fa51945851325eebc17f50ba80
-- name: go
   version: 1.16.6
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.6_linux_x64_cflinuxfs3_7f9ac238.tgz
   sha256: 7f9ac238a6adfd8bdc0efb7e0b320416c397ee752e281f78950f6881e77e0edb
@@ -57,6 +49,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.16.6.src.tar.gz
   source_sha256: a3a5d4bc401b51db065e4f93b523347a4d343ae0c0b08a65c3423b05a138037d
+- name: go
+  version: 1.16.7
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.7_linux_x64_cflinuxfs3_8a3a18cd.tgz
+  sha256: 8a3a18cd0af8b1cd87f633df914fcbef276d7f73de5b534b1a6220ac8c286b63
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.16.7.src.tar.gz
+  source_sha256: 1a9f2894d3d878729f7045072f30becebe243524cf2fce4e0a7b248b1e0654ac
 - name: godep
   version: '80'
   uri: https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v80-linux-x64-cflinuxfs3-b60ac947.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.