### PR TITLE
Updating version for go for 1.16.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,14 +26,6 @@ dependencies:
   source: https://github.com/Masterminds/glide/archive/v0.13.3.tar.gz
   source_sha256: 817dad2f25303d835789c889bf2fac5e141ad2442b9f75da7b164650f0de3fee
 - name: go
-  version: 1.16.6
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.6_linux_x64_cflinuxfs3_7f9ac238.tgz
-  sha256: 7f9ac238a6adfd8bdc0efb7e0b320416c397ee752e281f78950f6881e77e0edb
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.16.6.src.tar.gz
-  source_sha256: a3a5d4bc401b51db065e4f93b523347a4d343ae0c0b08a65c3423b05a138037d
-- name: go
   version: 1.16.7
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.7_linux_x64_cflinuxfs3_8a3a18cd.tgz
   sha256: 8a3a18cd0af8b1cd87f633df914fcbef276d7f73de5b534b1a6220ac8c286b63
@@ -41,6 +33,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.16.7.src.tar.gz
   source_sha256: 1a9f2894d3d878729f7045072f30becebe243524cf2fce4e0a7b248b1e0654ac
+- name: go
+  version: 1.16.8
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.8_linux_x64_cflinuxfs3_66355ad6.tgz
+  sha256: 66355ad618b6040d7a3b5ea166afeb12340326f073ff47d8028a869850c2dd32
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.16.8.src.tar.gz
+  source_sha256: 8f2a8c24b793375b3243df82fdb0c8387486dcc8a892ca1c991aa99ace086b98
 - name: go
   version: '1.17'
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17_linux_x64_cflinuxfs3_668718ba.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.