### PR TITLE
Updating version for go for 1.17.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -42,14 +42,6 @@ dependencies:
   source: https://dl.google.com/go/go1.16.8.src.tar.gz
   source_sha256: 8f2a8c24b793375b3243df82fdb0c8387486dcc8a892ca1c991aa99ace086b98
 - name: go
-  version: '1.17'
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17_linux_x64_cflinuxfs3_668718ba.tgz
-  sha256: 668718baed70ce6253d54c3bf15c36e764361ea0b19ff1e26e5bb491bc84570f
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.17.src.tar.gz
-  source_sha256: 3a70e5055509f347c0fb831ca07a2bf3b531068f349b14a3c652e9b5b67beb5d
-- name: go
   version: 1.17.1
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.1_linux_x64_cflinuxfs3_18d5168c.tgz
   sha256: 18d5168cd792eeff44a4062ce76c2fd5f6f9fee825cfe838f86b2ba5c0b06c71
@@ -57,6 +49,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.17.1.src.tar.gz
   source_sha256: 49dc08339770acd5613312db8c141eaf61779995577b89d93b541ef83067e5b1
+- name: go
+  version: 1.17.2
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.2_linux_x64_cflinuxfs3_f25fef22.tgz
+  sha256: f25fef22da5f07a57c5cb0ce1a91dac6d8b656a4e3e6405b36ada796a40e9a27
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.17.2.src.tar.gz
+  source_sha256: 2255eb3e4e824dd7d5fcdc2e7f84534371c186312e546fb1086a34c17752f431
 - name: godep
   version: '80'
   uri: https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v80-linux-x64-cflinuxfs3-b60ac947.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.