### PR TITLE
Updating version for go for 1.16.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,14 +26,6 @@ dependencies:
   source: https://github.com/Masterminds/glide/archive/v0.13.3.tar.gz
   source_sha256: 817dad2f25303d835789c889bf2fac5e141ad2442b9f75da7b164650f0de3fee
 - name: go
-  version: 1.16.7
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.7_linux_x64_cflinuxfs3_8a3a18cd.tgz
-  sha256: 8a3a18cd0af8b1cd87f633df914fcbef276d7f73de5b534b1a6220ac8c286b63
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.16.7.src.tar.gz
-  source_sha256: 1a9f2894d3d878729f7045072f30becebe243524cf2fce4e0a7b248b1e0654ac
-- name: go
   version: 1.16.8
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.8_linux_x64_cflinuxfs3_66355ad6.tgz
   sha256: 66355ad618b6040d7a3b5ea166afeb12340326f073ff47d8028a869850c2dd32
@@ -41,6 +33,14 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.16.8.src.tar.gz
   source_sha256: 8f2a8c24b793375b3243df82fdb0c8387486dcc8a892ca1c991aa99ace086b98
+- name: go
+  version: 1.16.9
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.9_linux_x64_cflinuxfs3_30f3df4e.tgz
+  sha256: 30f3df4ecebcf470fc33cdf236ecae17d8aef7ccc87e416a0e1b620330d4f0cd
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.16.9.src.tar.gz
+  source_sha256: 0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d
 - name: go
   version: 1.17.1
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.1_linux_x64_cflinuxfs3_18d5168c.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.