### PR TITLE
Updating version for go for 1.16.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -34,13 +34,13 @@ dependencies:
   source: https://dl.google.com/go/go1.16.9.src.tar.gz
   source_sha256: 0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d
 - name: go
-  version: 1.16.10
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.10_linux_x64_cflinuxfs3_5876822e.tgz
-  sha256: 5876822e692aaa3e1a52c9b2f18ebb3f9dab122f75e01700e2bd6286160294ee
+  version: 1.16.11
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16.11_linux_x64_cflinuxfs3_f3b33ebb.tgz
+  sha256: f3b33ebba56664f68fb16cbd157fe94b907a93c10214fa5e6f820739ac10a710
   cf_stacks:
   - cflinuxfs3
-  source: https://dl.google.com/go/go1.16.10.src.tar.gz
-  source_sha256: a905472011585e403d00d2a41de7ced29b8884309d73482a307f689fd0f320b5
+  source: https://dl.google.com/go/go1.16.11.src.tar.gz
+  source_sha256: 58041edcd81463b4cf1bc28b86dc0c17f4d9568d63c5afc85367dd8fae7befe7
 - name: go
   version: 1.17.2
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.2_linux_x64_cflinuxfs3_f25fef22.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.