### PR TITLE
Updating version for go for 1.17.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -50,13 +50,13 @@ dependencies:
   source: https://dl.google.com/go/go1.17.2.src.tar.gz
   source_sha256: 2255eb3e4e824dd7d5fcdc2e7f84534371c186312e546fb1086a34c17752f431
 - name: go
-  version: 1.17.3
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.3_linux_x64_cflinuxfs3_f64b0d7e.tgz
-  sha256: f64b0d7ed3a48b9a9449006e8684b86d5f79a1b10b0e0dcf50301813128ef597
+  version: 1.17.4
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.4_linux_x64_cflinuxfs3_c2697590.tgz
+  sha256: c2697590b36035928809674a54a90806fe08876674ba845f3de5bcb58013446e
   cf_stacks:
   - cflinuxfs3
-  source: https://dl.google.com/go/go1.17.3.src.tar.gz
-  source_sha256: 705c64251e5b25d5d55ede1039c6aa22bea40a7a931d14c370339853643c3df0
+  source: https://dl.google.com/go/go1.17.4.src.tar.gz
+  source_sha256: 4bef3699381ef09e075628504187416565d710660fec65b057edf1ceb187fc4b
 - name: godep
   version: '80'
   uri: https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v80-linux-x64-cflinuxfs3-b60ac947.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.