### PR TITLE
Updating version for go for 1.17.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -50,13 +50,13 @@ dependencies:
   source: https://dl.google.com/go/go1.17.2.src.tar.gz
   source_sha256: 2255eb3e4e824dd7d5fcdc2e7f84534371c186312e546fb1086a34c17752f431
 - name: go
-  version: 1.17.4
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.4_linux_x64_cflinuxfs3_c2697590.tgz
-  sha256: c2697590b36035928809674a54a90806fe08876674ba845f3de5bcb58013446e
+  version: 1.17.5
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.5_linux_x64_cflinuxfs3_e005a133.tgz
+  sha256: e005a133f7e7a5f63d8fa40d0088a1aed55a1d9f27fc51bc51e541188bf28657
   cf_stacks:
   - cflinuxfs3
-  source: https://dl.google.com/go/go1.17.4.src.tar.gz
-  source_sha256: 4bef3699381ef09e075628504187416565d710660fec65b057edf1ceb187fc4b
+  source: https://dl.google.com/go/go1.17.5.src.tar.gz
+  source_sha256: 3defb9a09bed042403195e872dcbc8c6fae1485963332279668ec52e80a95a2d
 - name: godep
   version: '80'
   uri: https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v80-linux-x64-cflinuxfs3-b60ac947.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.