### PR TITLE
Proxy tests should run offline to force use of the proxy

### DIFF
--- a/src/go/integration/proxy_test.go
+++ b/src/go/integration/proxy_test.go
@@ -37,6 +37,7 @@ func testProxy(platform switchblade.Platform, fixtures, uri string) func(*testin
 						"HTTP_PROXY":  uri,
 						"HTTPS_PROXY": uri,
 					}).
+					WithoutInternetAccess().
 					Execute(name, filepath.Join(fixtures, "glide", "simple"))
 				Expect(err).NotTo(HaveOccurred())
 
@@ -50,6 +51,7 @@ func testProxy(platform switchblade.Platform, fixtures, uri string) func(*testin
 							"HTTP_PROXY":  uri,
 							"HTTPS_PROXY": uri,
 						}).
+						WithoutInternetAccess().
 						Execute(name, filepath.Join(fixtures, "glide", "vendored"))
 					Expect(err).NotTo(HaveOccurred())
 
@@ -68,6 +70,7 @@ func testProxy(platform switchblade.Platform, fixtures, uri string) func(*testin
 						"HTTP_PROXY":  uri,
 						"HTTPS_PROXY": uri,
 					}).
+					WithoutInternetAccess().
 					Execute(name, filepath.Join(fixtures, "godep", "vendored"))
 				Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
The current tests configure a proxy, but their assertion isn't the best. We should turn off the network to force all traffic to go through the proxy to download dependencies. This will really ensure that the behavior we expect is working.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
