### PR TITLE
Update default Go version from '17.x' to '18.x'

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 language: go
 default_versions:
 - name: go
-  version: 1.17.x
+  version: 1.18.x
 dependency_deprecation_dates:
 - version_line: 1.17.x
   name: go
@@ -11,7 +11,11 @@ dependency_deprecation_dates:
 - version_line: 1.18.x
   name: go
   date: 2023-03-15
-  link: https://go.dev/doc/devel/release
+  link: https://golang.org/doc/devel/release.html
+- version_line: 1.19.x
+  name: go
+  date: 2023-09-16
+  link: https://golang.org/doc/devel/release.html
 dependencies:
 - name: dep
   version: 0.5.4


### PR DESCRIPTION
- Set Go `1.18` as the default version (`1.17` will be deprecated in the next BP release)
- Add information about `1.19` likely deprecation dates