### PR TITLE
Updating version for go for 1.18.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -30,22 +30,6 @@ dependencies:
   source: https://github.com/Masterminds/glide/archive/v0.13.3.tar.gz
   source_sha256: 817dad2f25303d835789c889bf2fac5e141ad2442b9f75da7b164650f0de3fee
 - name: go
-  version: 1.18.4
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.18.4_linux_x64_cflinuxfs3_baaa1e54.tgz
-  sha256: baaa1e546a6e5a5fc3cb2454e59b75bfe0b250f0bfa3b32a18aad0e2b0f5f716
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.18.4.src.tar.gz
-  source_sha256: 4525aa6b0e3cecb57845f4060a7075aafc9ab752bb7b6b4cf8a212d43078e1e4
-- name: go
-  version: 1.18.5
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.18.5_linux_x64_cflinuxfs3_c96d24dd.tgz
-  sha256: c96d24dd5becd7694c1ef1470791a825d0f0820c5ba16c12c252958843df2091
-  cf_stacks:
-  - cflinuxfs3
-  source: https://dl.google.com/go/go1.18.5.src.tar.gz
-  source_sha256: 9920d3306a1ac536cdd2c796d6cb3c54bc559c226fc3cc39c32f1e0bd7f50d2a
-- name: go
   version: 1.18.6
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.18.6_linux_x64_cflinuxfs3_99d9063d.tgz
   sha256: 99d9063da9bb8efc9ac85f94647088772675bc96f740e20bd4cf160b53918456
@@ -53,6 +37,22 @@ dependencies:
   - cflinuxfs3
   source: https://dl.google.com/go/go1.18.6.src.tar.gz
   source_sha256: a7f1d50424355dabce66d1112b1cae439b6ee5e4f15edba6f104c0a4b173e895
+- name: go
+  version: 1.18.7
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.18.7_linux_x64_cflinuxfs3_2136fb58.tgz
+  sha256: 2136fb58c64f4cd3bdea1b425b2391e6fba5f8aca68af5fa37f4530d0f26fb6e
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.18.7.src.tar.gz
+  source_sha256: 9467e33b819f71bebb21fb0ee1dd6794fd2244ae94907a984286712f9839a944
+- name: go
+  version: 1.18.7
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.18.7_linux_x64_cflinuxfs4_ddac3e8c.tgz
+  sha256: ddac3e8c82593fda2a8c4942f71643926c245180285f0ae0ee5c989834accdc0
+  cf_stacks:
+  - cflinuxfs4
+  source: https://dl.google.com/go/go1.18.7.src.tar.gz
+  source_sha256: 9467e33b819f71bebb21fb0ee1dd6794fd2244ae94907a984286712f9839a944
 - name: go
   version: '1.19'
   uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.19_linux_x64_cflinuxfs3_7e231ea5.tgz


### PR DESCRIPTION
This PR is made automatically by release engineering bot. [#181074448]