### PR TITLE
Remove brats assert no longer valid

### DIFF
--- a/src/go/brats/brats_test.go
+++ b/src/go/brats/brats_test.go
@@ -27,9 +27,6 @@ var _ = Describe("Go buildpack", func() {
 	bratshelper.StagingWithBuildpackThatSetsEOL(DEP, func(_ string) *cutlass.App {
 		return CopyBrats(GetOldestVersion(DEP, bpDir))
 	})
-	bratshelper.StagingWithADepThatIsNotTheLatest(DEP, func(_ string) *cutlass.App {
-		return CopyBrats(GetOldestVersion(DEP, bpDir))
-	})
 
 	bratshelper.StagingWithCustomBuildpackWithCredentialsInDependencies(CopyBrats)
 	bratshelper.DeployAppWithExecutableProfileScript(DEP, CopyBrats)


### PR DESCRIPTION
`StagingWithADepThatIsNotTheLatest` is no longer a valid test case, since in #307 we change the number of dependencies and only keep 1 patch for every version line