### PR TITLE
use /etc/os-release instead of lsb_release for OS info

### DIFF
--- a/src/go/supply/supply.go
+++ b/src/go/supply/supply.go
@@ -50,10 +50,10 @@ type Supplier struct {
 func Run(gs *Supplier) error {
 
 	gs.Log.Info("*** Starting cflinuxfs4 stack test logs***")
-	cmd := exec.Command("lsb_release", "-a")
+	cmd := exec.Command("cat", "/etc/os-release")
 	data, err := cmd.CombinedOutput()
 	if err != nil {
-		gs.Log.Error("failed to run lsb_release: %s", err.Error())
+		gs.Log.Error("failed to run cat /etc/os-release: %s", err.Error())
 	}
 	gs.Log.Info("Ubuntu Version Info: %s", data)
 


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
