### PR TITLE
Remove dependency credential test

### DIFF
--- a/src/go/brats/brats_test.go
+++ b/src/go/brats/brats_test.go
@@ -28,7 +28,6 @@ var _ = Describe("Go buildpack", func() {
 		return CopyBrats(GetOldestVersion(DEP, bpDir))
 	})
 
-	bratshelper.StagingWithCustomBuildpackWithCredentialsInDependencies(CopyBrats)
 	bratshelper.DeployAppWithExecutableProfileScript(DEP, CopyBrats)
 	bratshelper.DeployAnAppWithSensitiveEnvironmentVariables(CopyBrats)
 


### PR DESCRIPTION
- the change in CDN results in these tests failing, because the new CDN config does not support credentials in this way.
- we believe that consumers do not use this feature, as we have not had any reports of this causing failures for consumers.
- if we get reports that consumers cannot download dependencies from the CDN with credentials, and we deem this to be a necessary feature, we can update the CDN config and re-add these tests.
