### PR TITLE
feat: add support for GOVERSION=latest

### DIFF
--- a/src/go/supply/supply.go
+++ b/src/go/supply/supply.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver"
@@ -262,6 +263,13 @@ func (gs *Supplier) WriteConfigYml() error {
 
 func (gs *Supplier) parseGoVersion(partialGoVersion string) (string, error) {
 	existingVersions := gs.Manifest.AllDependencyVersions("go")
+
+	if partialGoVersion == "latest" {
+		slices.SortFunc(existingVersions, func(a, b string) int {
+			return semver.MustParse(b).Compare(semver.MustParse(a))
+		})
+		return existingVersions[0], nil
+	}
 
 	if len(strings.Split(partialGoVersion, ".")) < 3 {
 		partialGoVersion += ".x"

--- a/src/go/supply/supply_test.go
+++ b/src/go/supply/supply_test.go
@@ -387,6 +387,29 @@ var _ = Describe("Supply", func() {
 					Expect(gs.GoVersion).To(Equal("34.34.0"))
 				})
 			})
+
+			Context("GOVERSION is 'latest'", func() {
+				var oldGOVERSION string
+
+				BeforeEach(func() {
+					oldGOVERSION = os.Getenv("GOVERSION")
+					err = os.Setenv("GOVERSION", "latest")
+					Expect(err).To(BeNil())
+					vendorTool = "go_nativevendoring"
+				})
+
+				AfterEach(func() {
+					err = os.Setenv("GOVERSION", oldGOVERSION)
+					Expect(err).To(BeNil())
+				})
+
+				It("sets the go version from GOVERSION", func() {
+					err = gs.SelectGoVersion()
+					Expect(err).To(BeNil())
+
+					Expect(gs.GoVersion).To(Equal("34.34.0"))
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
This will automatically check the go versions listed in the manifest
and ensure that the version returned is the highest semver version as
listed in the manifest.
