### PR TITLE
fix(online buildpack): Update Go version used for online buildpack

### DIFF
--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -12,17 +12,15 @@ function main() {
   fi
 
   local version expected_sha dir
-  version="1.22.5"
-  expected_sha="ddb12ede43eef214c7d4376761bd5ba6297d5fa7a06d5635ea3e7a276b3db730"
+  version="1.25.6"
+  expected_sha="0ed64e3b9cb9b1c2ec57880dae2427b0ee2676f2ae2fb53c2e1bb838c500f9fb"
   dir="/tmp/go${version}"
 
   mkdir -p "${dir}"
 
   if [[ ! -f "${dir}/bin/go" ]]; then
     local url
-    # TODO: use exact stack based dep, after go buildpack has cflinuxfs4 support
-    #url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_${CF_STACK}_${expected_sha:0:8}.tgz"
-    url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_cflinuxfs3_${expected_sha:0:8}.tgz"
+    url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_${CF_STACK}_${expected_sha:0:8}.tgz"
 
     echo "-----> Download go ${version}"
     curl "${url}" \


### PR DESCRIPTION
# Issue

Using the Go buildpack with `GOTOOLCHAIN=local` as an online buildpack started to fail after https://github.com/cloudfoundry/go-buildpack/pull/516 as the `go.mod` requires a Go > 1.23 but the `install_go.sh` scripts still downloads Go 1.22.

Without `GOTOOLCHAIN=local` it downloads Go 1.24 as required by the `go toolchain` line in `go.mod`:

```
   2025-08-18T17:45:00.33+0200 [STG/0] OUT -----> Download go 1.22.5
   2025-08-18T17:45:03.60+0200 [STG/0] OUT -----> Running go build supply
   2025-08-18T17:45:03.60+0200 [STG/0] OUT /tmp/buildpackdownloads/45909db73807128d ~
   2025-08-18T17:45:03.61+0200 [STG/0] ERR go: downloading go1.24.0 (linux/amd64)
```

With `GOTOOLCHAIN=local` it fails:

```
   2025-08-18T17:48:52.53+0200 [STG/0] OUT -----> Download go 1.22.5
   2025-08-18T17:48:55.77+0200 [STG/0] OUT -----> Running go build supply
   2025-08-18T17:48:55.77+0200 [STG/0] OUT /tmp/buildpackdownloads/45909db73807128d ~
   2025-08-18T17:48:55.77+0200 [STG/0] ERR go: go.mod requires go >= 1.23.0 (running go 1.22.5; GOTOOLCHAIN=local)
   2025-08-18T17:48:55.77+0200 [STG/0] ERR Failed to compile droplet: Failed to run all supply scripts: exit status 1
 ```

 # Fix

 Bump Go version to the latest currently in `manifest.yml`:

```
   -----> Download go 1.24.6
   -----> Running go build supply
   /tmp/buildpackdownloads/a01824c08ac24e60 ~
   ~
   -----> Go Buildpack version 1.10.38
```

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [ ] I have added an integration test
  No, it's just a dependency bump.
