### PR TITLE
adopt switchblade 0.9.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/ZiCog/shiny-thing v0.0.0-20121130081921-e9e19444ccf5
 	github.com/cloudfoundry/libbuildpack v0.0.0-20251203175254-7be530ec9fef
-	github.com/cloudfoundry/switchblade v0.9.2
+	github.com/cloudfoundry/switchblade v0.9.4
 	github.com/golang/mock v1.6.0
 	github.com/kr/go-heroku-example v0.0.0-20150601175414-712a6d2f98f1
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -748,8 +748,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudfoundry/libbuildpack v0.0.0-20251203175254-7be530ec9fef h1:lrggsL5p4dr3bBK/x1xIu3sn/6PGYV71GQIe/mCNfFw=
 github.com/cloudfoundry/libbuildpack v0.0.0-20251203175254-7be530ec9fef/go.mod h1:kn4FHMwI8bTd9gT92wPGjXHzUvGcj8CkPxG8q3AGBAQ=
-github.com/cloudfoundry/switchblade v0.9.2 h1:b2lwxrAblg9uKncNQRKZ09/teuKdZIixcENKgrLQPjo=
-github.com/cloudfoundry/switchblade v0.9.2/go.mod h1:hIEQdGAsuNnzlyQfsD5OIORt38weSBar6Wq5/JX6Omo=
+github.com/cloudfoundry/switchblade v0.9.4 h1:93O90a/DRRcZ4h50htDh4z7+FMliqy/lQH6IFgVa+mQ=
+github.com/cloudfoundry/switchblade v0.9.4/go.mod h1:hIEQdGAsuNnzlyQfsD5OIORt38weSBar6Wq5/JX6Omo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/vendor/github.com/cloudfoundry/switchblade/README.md
+++ b/vendor/github.com/cloudfoundry/switchblade/README.md
@@ -175,6 +175,31 @@ deployment, logs, err := platform.Deploy.
   Execute("my-app", "/path/to/my/app/source")
 ```
 
+### Retrieving runtime logs: `RuntimeLogs`
+
+The `deployment.RuntimeLogs()` method retrieves logs from the running application
+after deployment succeeds. This is useful for testing runtime behavior such as
+application startup, service connections, and module loading.
+
+```go
+// Deploy an application
+deployment, stagingLogs, err := platform.Deploy.Execute("my-app", "/path/to/my/app/source")
+Expect(err).NotTo(HaveOccurred())
+
+// stagingLogs contains build-time output (buildpack detection, compilation, etc.)
+Expect(stagingLogs).To(ContainLines(ContainSubstring("Installing dependencies...")))
+
+// Retrieve runtime logs (application startup, service connections, etc.)
+runtimeLogs, err := deployment.RuntimeLogs()
+Expect(err).NotTo(HaveOccurred())
+Expect(runtimeLogs).To(ContainSubstring("Application started"))
+Expect(runtimeLogs).To(ContainSubstring("Connected to Redis"))
+```
+
+**Note:** The logs returned from `platform.Deploy.Execute()` are **staging logs**
+(build-time), while `deployment.RuntimeLogs()` returns **runtime logs** (post-deployment).
+Use staging logs to test buildpack behavior, and runtime logs to test application behavior.
+
 ## Other utilities
 
 ### Random name generation: `RandomName`

--- a/vendor/github.com/cloudfoundry/switchblade/cloudfoundry.go
+++ b/vendor/github.com/cloudfoundry/switchblade/cloudfoundry.go
@@ -14,11 +14,11 @@ import (
 //go:generate faux --package github.com/cloudfoundry/switchblade/internal/cloudfoundry --interface StagePhase --name CloudFoundryStagePhase --output fakes/cloudfoundry_stage_phase.go
 //go:generate faux --package github.com/cloudfoundry/switchblade/internal/cloudfoundry --interface TeardownPhase --name CloudFoundryTeardownPhase --output fakes/cloudfoundry_teardown_phase.go
 
-func NewCloudFoundry(initialize cloudfoundry.InitializePhase, deinitialize cloudfoundry.DeinitializePhase, setup cloudfoundry.SetupPhase, stage cloudfoundry.StagePhase, teardown cloudfoundry.TeardownPhase, workspace string) Platform {
+func NewCloudFoundry(initialize cloudfoundry.InitializePhase, deinitialize cloudfoundry.DeinitializePhase, setup cloudfoundry.SetupPhase, stage cloudfoundry.StagePhase, teardown cloudfoundry.TeardownPhase, workspace string, cli cloudfoundry.Executable) Platform {
 	return Platform{
 		initialize:   cloudFoundryInitializeProcess{initialize: initialize},
 		deinitialize: cloudFoundryDeinitializeProcess{deinitialize: deinitialize},
-		Deploy:       cloudFoundryDeployProcess{setup: setup, stage: stage, workspace: workspace},
+		Deploy:       cloudFoundryDeployProcess{setup: setup, stage: stage, workspace: workspace, cli: cli},
 		Delete:       cloudFoundryDeleteProcess{teardown: teardown, workspace: workspace},
 	}
 }
@@ -51,6 +51,7 @@ type cloudFoundryDeployProcess struct {
 	setup     cloudfoundry.SetupPhase
 	stage     cloudfoundry.StagePhase
 	workspace string
+	cli       cloudfoundry.Executable
 }
 
 func (p cloudFoundryDeployProcess) WithBuildpacks(buildpacks ...string) DeployProcess {
@@ -111,6 +112,9 @@ func (p cloudFoundryDeployProcess) Execute(name, source string) (Deployment, fmt
 		Name:        name,
 		ExternalURL: externalURL,
 		InternalURL: internalURL,
+		platform:    CloudFoundry,
+		workspace:   home,
+		cfCLI:       p.cli,
 	}, logs, nil
 }
 

--- a/vendor/github.com/cloudfoundry/switchblade/deployment.go
+++ b/vendor/github.com/cloudfoundry/switchblade/deployment.go
@@ -1,7 +1,77 @@
 package switchblade
 
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/cloudfoundry/switchblade/internal/cloudfoundry"
+	"github.com/docker/docker/api/types/container"
+)
+
+//go:generate faux --interface LogsClient --output fakes/logs_client.go
+type LogsClient interface {
+	ContainerLogs(ctx context.Context, container string, options container.LogsOptions) (io.ReadCloser, error)
+}
+
 type Deployment struct {
 	Name        string
 	ExternalURL string
 	InternalURL string
+
+	// Internal fields for log retrieval
+	platform  string
+	workspace string
+	cfCLI     cloudfoundry.Executable
+	dockerCLI LogsClient
+}
+
+// RuntimeLogs retrieves recent logs from the running application.
+// These are logs generated after the application has started (post-staging).
+// This method abstracts platform-specific log retrieval for both
+// CloudFoundry and Docker platforms.
+//
+// Use this for testing:
+//   - Application startup messages
+//   - Service connections
+//   - Module/extension loading
+//   - Runtime configuration
+//
+// For build-time logs (staging, buildpack detection), use the logs
+// returned from platform.Deploy.Execute() instead.
+func (d Deployment) RuntimeLogs() (string, error) {
+	switch d.platform {
+	case CloudFoundry:
+		return d.logsCloudFoundry()
+	case Docker:
+		return d.logsDocker()
+	default:
+		return "", fmt.Errorf("unknown platform type: %q", d.platform)
+	}
+}
+
+func (d Deployment) logsCloudFoundry() (string, error) {
+	return cloudfoundry.FetchRecentLogs(d.cfCLI, d.workspace, d.Name)
+}
+
+func (d Deployment) logsDocker() (string, error) {
+	ctx := context.Background()
+
+	options := container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+	}
+
+	reader, err := d.dockerCLI.ContainerLogs(ctx, d.Name, options)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve container logs: %w", err)
+	}
+	defer reader.Close()
+
+	logs, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("failed to read logs: %w", err)
+	}
+
+	return string(logs), nil
 }

--- a/vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/logs.go
+++ b/vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/logs.go
@@ -1,0 +1,28 @@
+package cloudfoundry
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/paketo-buildpacks/packit/v2/pexec"
+)
+
+// FetchRecentLogs retrieves recent application logs using 'cf logs --recent'.
+// This is a shared helper used for both staging failures and runtime log retrieval.
+func FetchRecentLogs(cli Executable, home, appName string) (string, error) {
+	env := append(os.Environ(), fmt.Sprintf("CF_HOME=%s", home))
+	buffer := bytes.NewBuffer(nil)
+
+	err := cli.Execute(pexec.Execution{
+		Args:   []string{"logs", appName, "--recent"},
+		Stdout: buffer,
+		Stderr: buffer,
+		Env:    env,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve logs: %w", err)
+	}
+
+	return buffer.String(), nil
+}

--- a/vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/setup.go
+++ b/vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/setup.go
@@ -183,7 +183,12 @@ func (s Setup) Run(log io.Writer, home, name, source string) (string, error) {
 			Env:    env,
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to create-shared-domain: %w\n\nOutput:\n%s", err, log)
+			logStr := log.(*bytes.Buffer).String()
+			if strings.Contains(logStr, "already in use") {
+				fmt.Fprintf(log, "TCP domain already exists, continuing...\n")
+			} else {
+				return "", fmt.Errorf("failed to create-shared-domain: %w\n\nOutput:\n%s", err, log)
+			}
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -32,7 +32,7 @@ github.com/cloudfoundry/libbuildpack/cutlass
 github.com/cloudfoundry/libbuildpack/cutlass/docker
 github.com/cloudfoundry/libbuildpack/cutlass/glow
 github.com/cloudfoundry/libbuildpack/packager
-# github.com/cloudfoundry/switchblade v0.9.2
+# github.com/cloudfoundry/switchblade v0.9.4
 ## explicit; go 1.23.0
 github.com/cloudfoundry/switchblade
 github.com/cloudfoundry/switchblade/internal/cloudfoundry


### PR DESCRIPTION
chore(deps): upgrade to switchblade v0.9.4

- Update switchblade dependency from v0.9.2 to v0.9.4
- Vendored updated switchblade libraries with improvements to deployment handling
- Key changes in v0.9.4:
  * Enhanced deployment interface with improved RuntimeLogs() return type (now returns string directly)
  * Improved CloudFoundry logs handling in internal/cloudfoundry/logs.go
  * Updated docker.go and cloudfoundry.go platform implementations
  * Better error handling in stage.go

This upgrade fixes type assertion issues in integration tests and provides better
API consistency across platform implementations.
