### PR TITLE
Pin setup-go action version to go v1.24

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Setup Go
-        uses: actions/setup-go@1.24
+        uses: actions/setup-go@v4
         with:
           go-version: stable
 


### PR DESCRIPTION
Pin setup-go action version to use go v1.24 as the latest version has different behaviour

