### PR TITLE
Pin Go to 1.24 in test-pull-request workflow

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.24'
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.24'
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Go 1.26 introduced breaking changes that prevent zip file creation for buildpack archives. 
Pin to Go 1.24 until the issue is resolved.

